### PR TITLE
Fix Haddock markup

### DIFF
--- a/src/Error/Diagnose.hs
+++ b/src/Error/Diagnose.hs
@@ -105,7 +105,7 @@ import Error.Diagnose.Style as Export
 --
 --         This marker is output in red in an error report, and yellow in a warning report.
 --
---   - A 'Error.Diagnose.Report.Where' marker contains additional information/provides context to the error/warning report.
+--   - A 'Error.Diagnose.Report.Where' marker contains additional information\/provides context to the error\/warning report.
 --     For example, it may underline where a given variable @x@ is bound to emphasize it.
 --
 --         This marker is output in blue.

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -113,7 +113,7 @@ addFile ::
   Diagnostic msg ->
   -- | The path to the file.
   FilePath ->
-  -- | The content of the file as a single string, where lines are ended by @\n@.
+  -- | The content of the file as a single string, where lines are ended by @\\n@.
   String ->
   Diagnostic msg
 addFile (Diagnostic reports files) path content =


### PR DESCRIPTION
Forward slashes have to be escaped otherwise they indicate emphasized markup:

<img width="549" alt="Screenshot of the (unfixed) rendered markup which reads “A Where marker contains additional informationprovides (sic!) context to the errorwarning (sic!) report.”" src="https://user-images.githubusercontent.com/2131598/175787754-d43cb6c6-d2e9-4123-a462-847dbe6ba66f.png">

Backslashes have to be escaped as well:

<img width="420" alt="Screenshot of the (unfixed) rendered markup which reads “The content of the file as a single string, where lines are encoded by n (sic!)”" src="https://user-images.githubusercontent.com/2131598/175788183-d4d7776b-8df2-4d1f-91de-6c66174e5242.png">

