### PR TITLE
Performance improvements

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.6.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -67,6 +67,7 @@ library
   build-depends:
       base >=4.7 && <5
     , data-default >=0.7 && <1
+    , dlist ==1.0.*
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.0 && <2
@@ -111,6 +112,7 @@ test-suite diagnose-megaparsec-tests
       base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
+    , dlist ==1.0.*
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.0 && <2
@@ -150,6 +152,7 @@ test-suite diagnose-parsec-tests
       base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
+    , dlist ==1.0.*
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.0 && <2
@@ -188,6 +191,7 @@ test-suite diagnose-rendering-tests
       base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
+    , dlist ==1.0.*
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.0 && <2

--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -65,7 +65,8 @@ library
       BlockArguments
   ghc-options: -Wall -Wextra
   build-depends:
-      base >=4.7 && <5
+      array ==0.5.*
+    , base >=4.7 && <5
     , data-default >=0.7 && <1
     , dlist ==1.0.*
     , hashable >=1.3 && <2
@@ -109,7 +110,8 @@ test-suite diagnose-megaparsec-tests
       BlockArguments
   ghc-options: -Wall -Wextra -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      array ==0.5.*
+    , base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*
@@ -149,7 +151,8 @@ test-suite diagnose-parsec-tests
       BlockArguments
   ghc-options: -Wall -Wextra -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      array ==0.5.*
+    , base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*
@@ -188,7 +191,8 @@ test-suite diagnose-rendering-tests
       BlockArguments
   ghc-options: -Wall -Wextra -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      base >=4.7 && <5
+      array ==0.5.*
+    , base >=4.7 && <5
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*

--- a/package.yaml
+++ b/package.yaml
@@ -8,6 +8,7 @@ category: "Error Reporting"
 
 dependencies:
 - base >= 4.7 && < 5
+- array >= 0.5 && < 0.6
 - data-default >= 0.7 && < 1
 - dlist >= 1.0 && < 1.1
 - hashable >= 1.3 && < 2

--- a/package.yaml
+++ b/package.yaml
@@ -8,11 +8,12 @@ category: "Error Reporting"
 
 dependencies:
 - base >= 4.7 && < 5
+- data-default >= 0.7 && < 1
+- dlist >= 1.0 && < 1.1
+- hashable >= 1.3 && < 2
 - prettyprinter >= 1.7.0 && < 2
 - prettyprinter-ansi-terminal >= 1.1.0 && < 2
 - unordered-containers >= 0.2 && < 0.3
-- hashable >= 1.3 && < 2
-- data-default >= 0.7 && < 1
 - wcwidth >= 0.0.1 && <1
 - text >= 1.0.0.0 && <= 2.0
 # ^^^ This is unfortunately required, but as 'prettyprinter' already depends on it, it will already have been fetched

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -20,8 +20,11 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson (ToJSON(..), encode, object, (.=))
 import Data.ByteString.Lazy (ByteString)
 #endif
+
+import Data.DList (DList)
+import qualified Data.DList as DL
 import Data.Default (Default, def)
-import Data.Foldable (fold)
+import Data.Foldable (fold, toList)
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.List (intersperse)
@@ -38,7 +41,7 @@ import System.IO (Handle)
 --   to create a new empty diagnostic, and 'addFile' and 'addReport' to alter its internal state.
 data Diagnostic msg
   = Diagnostic
-      [Report msg]
+      (DList (Report msg))
       -- ^ All the reports contained in a diagnostic.
       --
       --   Reports are output one by one, without connections in between.
@@ -85,7 +88,7 @@ prettyDiagnostic ::
   Diagnostic msg ->
   Doc Annotation
 prettyDiagnostic withUnicode tabSize (Diagnostic reports file) =
-  fold . intersperse hardline $ prettyReport file withUnicode tabSize <$> reports
+  fold . intersperse hardline $ prettyReport file withUnicode tabSize <$> toList reports
 {-# INLINE prettyDiagnostic #-}
 
 -- | Prints a 'Diagnostic' onto a specific 'Handle'.
@@ -127,7 +130,7 @@ addReport ::
   Report msg ->
   Diagnostic msg
 addReport (Diagnostic reports files) report =
-  Diagnostic (reports <> [report]) files
+  Diagnostic (reports `DL.snoc` report) files
 {-# INLINE addReport #-}
 
 #ifdef USE_AESON


### PR DESCRIPTION
While looking at the code (I'm considering using this very nicely looking library for better error messages in [JaSpa/AlgST](https://github.com/JaSpa/AlgST)) I saw some potential for performance improvements. Some numbers:

|                      |    big/string | test-suite/string |
|---------------------:|--------------:|------------------:|
|           **v2.1.1** |   `284.50 ms` |        `778.9 μs` |
|         **improved** |    `58.71 ms` |        `686.5 μs` |
| absolute improvement | `- 225.79 ms` |       `- 92.4 μs` |
| relative improvement |  `- 79.36 % ` |       `- 11.86 %` |

These numbers show
1. there is large potential for improvement in large cases
2. smaller cases improve as well/don't get slower

Below I detail the benchmark setup I used and explain the changes I made. If you have any questions, please don't hesitate!

I verified that the test-suite output before and after is byte identical. (There *is* actually one change but the representation is the same: in the unicode.txt test case a sequence of spaces changes from each space being highlighted by itself to the whole chunk being highlighted at once. I don't really see where I introduced this but I won't investigate further as I think this change is harmless.)

### Benchmark Setup

The code is available at https://gist.github.com/JaSpa/0d6a267351c6d91daddb73838270ea72.  
Full results are at https://gist.github.com/JaSpa/032501608da016b84a6cb3a55377e723

The test case *big/string* generates a report with a single marker for every line of a file with ~3600 lines (6 concatenations of Report/Internal.hs at 73c2f2b—the specific size is admittedly quite arbitrary. The diagnostic is rendered using [`layoutCompact`](https://hackage.haskell.org/package/prettyprinter-1.7.1/docs/Prettyprinter-Internal.html#v:layoutCompact) to cut down on the influence of the layout algorithm.

The test case *test-suite/string* uses the same diagnostic/reports/files as the test suite and the same layouting as described above.

Additionally, I benchmarked the *big* case, as well as the *test-suite* case, with JSON output. These numbers change only very little. This is expected, as most of the changes revolve around `getLine_` which is not used for JSON output. I included it mostly for sanity checking that I don't something unrelated worse.

If you're interested I can help with integrating the benchmarks into the repository.

### Applied Improvements/Rationales

* Use difference lists when accumulating reports. This results in `addReport` running in *O(1)* instead of *O(n)*. Overall for *n* reports this improves the run time from *O(n²)* to *O(n)*.

  ```
  big/string		-132.3ms
  test-suite/string	  -1.9μs
  ```

* Calculate character widths per line in an array.

  Using an unboxed array has better performance than using a
  `HashMap Int Int`; although both data structures support O(1) access,
  the array has a better constant factor.

  Additionally, an array is suited very well since we we have a character
  width for every index i in [1..n].


  ```
  big/string		  -3.7ms
  test-suite/string	 -97.8μs
  ```

  Here the impact on the *test-suite/string* case is larger than the *big/string* case because in the former there are multiple markers and therefore the access performance carries more weight.

* Store a file's lines in an array. Another *O(n²)* to *O(n)* improvement (here *n* being the number of lines in a file): Haskell's lists are very not-suited for indexed access (`List.safeIndex`). `Seq` from *containers* is a better choice but since we do not have to add/remove any elements we can use an array which is even faster.
  
  ```
  big/string		-89.79ms
  test-suite/string	 +7.3μs
  ```

  The impact of this change is especially high in the *big/string* case because of the big file. The test-suite files, however, are very small. Here the `List.safeIndex` is nearly *O(1)* anyways and the array constructions constant factor results in the slight increases in runtime.