### PR TITLE
Add functionality to render diagnostics with user provided Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ let diagnostic  = addFile def "somefile.zc" "let id<a>(x : a) : a := x\n  + 1"
 let diagnostic' = addReport diagnostic beautifulExample
 
 -- Print with unicode characters, colors and the default style
-printDiagnostic stdout True True 4 defaultStyle diagnostic'
+printDiagnostic stdout True 4 defaultStyle diagnostic'
 ```
 
 More examples are given in the [`test/rendering`](./test/rendering) folder (execute `stack test` to see the output).

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ let beautifulExample =
 let diagnostic  = addFile def "somefile.zc" "let id<a>(x : a) : a := x\n  + 1"
 let diagnostic' = addReport diagnostic beautifulExample
 
--- Print with unicode characters, colors and the default style
-printDiagnostic stdout True 4 defaultStyle diagnostic'
+-- Print with unicode characters, and the default (colorful) style
+printDiagnostic stdout WithUnicode 4 defaultStyle diagnostic'
 ```
 
 More examples are given in the [`test/rendering`](./test/rendering) folder (execute `stack test` to see the output).

--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           diagnose
-version:        2.4.0
+version:        2.5.0
 synopsis:       Beautiful error reporting done easily
 description:    This package provides a simple way of getting beautiful compiler/interpreter errors
                 using a very simple interface for the programmer.

--- a/src/Error/Diagnose.hs
+++ b/src/Error/Diagnose.hs
@@ -241,7 +241,7 @@ import Error.Diagnose.Style as Export
 --   >            --   Creates a new diagnostic with no default hints from the bundle returned by megaparsec
 --   >         diag' = addFile diag filename content
 --   >            --   Add the file used when parsing with the same filename given to 'MP.runParser'
---   >     in printDiagnostic stderr True True 4 diag'
+--   >     in printDiagnostic stderr True 4 diag'
 --   >   Right res   -> print res
 --
 --   This example will return the following error message (assuming default instances for @'Error.Diagnose.Compat.Megaparsec.HasHints' 'Data.Void.Void' msg@):
@@ -282,7 +282,7 @@ import Error.Diagnose.Style as Export
 --   >            --   Creates a new diagnostic with no default hints from the bundle returned by megaparsec
 --   >         diag' = addFile diag filename content
 --   >            --   Add the file used when parsing with the same filename given to 'MP.runParser'
---   >     in printDiagnostic stderr True True 4 diag'
+--   >     in printDiagnostic stderr True 4 diag'
 --   >   Right res  -> print res
 --
 --   This will output the following error on @stderr@:

--- a/src/Error/Diagnose/Diagnostic.hs
+++ b/src/Error/Diagnose/Diagnostic.hs
@@ -25,7 +25,9 @@ import Error.Diagnose.Diagnostic.Internal as Export
     hasReports,
     reportsOf,
     prettyDiagnostic,
+    prettyDiagnostic',
     printDiagnostic,
+    printDiagnostic',
     warningsToErrors,
   )
 import System.IO as Export (stderr, stdout)

--- a/src/Error/Diagnose/Diagnostic.hs
+++ b/src/Error/Diagnose/Diagnostic.hs
@@ -29,5 +29,7 @@ import Error.Diagnose.Diagnostic.Internal as Export
     printDiagnostic,
     printDiagnostic',
     warningsToErrors,
+    WithUnicode(..),
+    TabSize(..),
   )
 import System.IO as Export (stderr, stdout)

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -16,7 +16,7 @@
 --            It is also highly undocumented.
 --
 --            Please limit yourself to the "Error.Diagnose.Diagnostic" module, which exports some of the useful functions defined here.
-module Error.Diagnose.Diagnostic.Internal (module Error.Diagnose.Diagnostic.Internal, def) where
+module Error.Diagnose.Diagnostic.Internal (module Error.Diagnose.Diagnostic.Internal, def, WithUnicode(..), TabSize(..)) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
 #ifdef USE_AESON
@@ -32,7 +32,7 @@ import Data.Foldable (fold, toList)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.List (intersperse)
 import Error.Diagnose.Report (Report)
-import Error.Diagnose.Report.Internal (FileMap, errorToWarning, prettyReport, warningToError)
+import Error.Diagnose.Report.Internal (FileMap, errorToWarning, prettyReport, warningToError, WithUnicode(..), TabSize(..))
 import Error.Diagnose.Style (Annotation, Style)
 import Prettyprinter (Doc, Pretty, hardline, pretty, defaultLayoutOptions, reAnnotateS, layoutPretty)
 import Prettyprinter.Render.Terminal (renderIO)
@@ -102,9 +102,9 @@ errorsToWarnings (Diagnostic reports files) = Diagnostic (errorToWarning <$> rep
 prettyDiagnostic ::
   Pretty msg =>
   -- | Should we use unicode when printing paths?
-  Bool ->
+  WithUnicode ->
   -- | The number of spaces each TAB character will span.
-  Int ->
+  TabSize ->
   -- | The diagnostic to print.
   Diagnostic msg ->
   Doc (Annotation ann)
@@ -117,9 +117,9 @@ prettyDiagnostic withUnicode tabSize =
 -- annotations are retained in 'OtherStyle'
 prettyDiagnostic' ::
   -- | Should we use unicode when printing paths?
-  Bool ->
+  WithUnicode ->
   -- | The number of spaces each TAB character will span.
-  Int ->
+  TabSize ->
   -- | The diagnostic to print.
   Diagnostic (Doc ann) ->
   Doc (Annotation ann)
@@ -132,9 +132,9 @@ printDiagnostic ::
   -- | The handle onto which to output the diagnostic.
   Handle ->
   -- | Should we print with unicode characters?
-  Bool ->
+  WithUnicode ->
   -- | The number of spaces each TAB character will span.
-  Int ->
+  TabSize ->
   -- | The style in which to output the diagnostic.
   Style ann ->
   -- | The diagnostic to output.
@@ -151,9 +151,9 @@ printDiagnostic' ::
   -- | The handle onto which to output the diagnostic.
   Handle ->
   -- | Should we print with unicode characters?
-  Bool ->
+  WithUnicode ->
   -- | The number of spaces each TAB character will span.
-  Int ->
+  TabSize ->
   -- | The style in which to output the diagnostic.
   Style ann ->
   -- | The diagnostic to output.

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -34,8 +34,8 @@ import Data.List (intersperse)
 import Error.Diagnose.Report (Report)
 import Error.Diagnose.Report.Internal (FileMap, errorToWarning, prettyReport, warningToError)
 import Error.Diagnose.Style (Annotation, Style)
-import Prettyprinter (Doc, Pretty, hardline, unAnnotate, pretty)
-import Prettyprinter.Render.Terminal (hPutDoc, AnsiStyle)
+import Prettyprinter (Doc, Pretty, hardline, unAnnotate)
+import Prettyprinter.Render.Terminal (hPutDoc)
 import System.IO (Handle)
 
 -- | The data type for diagnostic containing messages of an abstract type.
@@ -108,24 +108,9 @@ prettyDiagnostic ::
   -- | The diagnostic to print.
   Diagnostic msg ->
   Doc Annotation
-prettyDiagnostic withUnicode tabSize =
-  prettyDiagnostic' id withUnicode tabSize . fmap pretty
+prettyDiagnostic withUnicode tabSize (Diagnostic reports file) =
+  fold . intersperse hardline $ prettyReport file withUnicode tabSize <$> toList reports
 {-# INLINE prettyDiagnostic #-}
-
--- | Like 'prettyDiagnostic', but instead of requiring a 'Pretty' instance for
--- diagnostic messages this allows you to provide your own 'Doc's
-prettyDiagnostic' ::
-  -- | How to reannotate Diagnose's output
-  (Annotation -> ann) ->
-  -- | Should we use unicode when printing paths?
-  Bool ->
-  -- | The number of spaces each TAB character will span.
-  Int ->
-  -- | The diagnostic to print.
-  Diagnostic (Doc ann) ->
-  Doc ann
-prettyDiagnostic' sty withUnicode tabSize (Diagnostic reports file) =
-  fold . intersperse hardline $ prettyReport sty file withUnicode tabSize <$> toList reports
 
 -- | Prints a 'Diagnostic' onto a specific 'Handle'.
 printDiagnostic ::
@@ -143,27 +128,9 @@ printDiagnostic ::
   -- | The diagnostic to output.
   Diagnostic msg ->
   m ()
-printDiagnostic handle withUnicode withColors tabSize style =
-  printDiagnostic' handle withUnicode tabSize (if withColors then style else const mempty) . fmap pretty
+printDiagnostic handle withUnicode withColors tabSize style diag =
+  liftIO $ hPutDoc handle ((if withColors then style else unAnnotate) $ prettyDiagnostic withUnicode tabSize diag)
 {-# INLINE printDiagnostic #-}
-
--- | Like 'printDiagnostic', but instead of requiring a 'Pretty' instance for
--- diagnostic messages this allows you to provide your own 'Doc's
-printDiagnostic' ::
-  (MonadIO m) =>
-  -- | The handle onto which to output the diagnostic.
-  Handle ->
-  -- | Should we print with unicode characters?
-  Bool ->
-  -- | The number of spaces each TAB character will span.
-  Int ->
-  -- | How to reannotate Diagnose's output
-  (Annotation -> AnsiStyle) ->
-  -- | The diagnostic to output.
-  Diagnostic (Doc AnsiStyle) ->
-  m ()
-printDiagnostic' handle withUnicode tabSize sty diag =
-  liftIO $ hPutDoc handle (prettyDiagnostic' sty withUnicode tabSize diag)
 
 -- | Inserts a new referenceable file within the diagnostic.
 addFile ::

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 -- |
@@ -47,6 +50,7 @@ data Diagnostic msg
       --   Reports are output one by one, without connections in between.
       !FileMap
       -- ^ A map associating files with their content as lists of lines.
+  deriving (Functor, Foldable, Traversable)
 
 instance Default (Diagnostic msg) where
   def = Diagnostic mempty mempty

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 

--- a/src/Error/Diagnose/Pretty.hs
+++ b/src/Error/Diagnose/Pretty.hs
@@ -1,4 +1,3 @@
 module Error.Diagnose.Pretty (module Export) where
 
 import qualified Prettyprinter as Export 
-import qualified Prettyprinter.Render.Terminal as Export 

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiWayIf #-}

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -155,7 +155,7 @@ data Note msg
     Note msg
   | -- | A hint, to propose potential fixes or help towards fixing the issue.
     Hint msg
-  deriving (Functor, Foldable, Traversable)
+  deriving (Eq, Ord, Show, Functor, Foldable, Traversable)
 
 #ifdef USE_AESON
 instance ToJSON msg => ToJSON (Note msg) where

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -50,7 +50,7 @@ import Data.String (IsString (fromString))
 import qualified Data.Text as Text
 import Error.Diagnose.Position
 import Error.Diagnose.Style (Annotation (..))
-import Prettyprinter (Doc, Pretty (..), align, annotate, colon, hardline, lbracket, rbracket, space, width, (<+>), reAnnotate)
+import Prettyprinter (Doc, Pretty (..), align, annotate, colon, hardline, lbracket, rbracket, space, width, (<+>))
 import Prettyprinter.Internal (Doc (..))
 
 type FileMap = HashMap FilePath (Array Int String)
@@ -195,8 +195,7 @@ errorToWarning r@(Report False _ _ _ _) = r
 
 -- | Pretty prints a report to a 'Doc' handling colors.
 prettyReport ::
-  -- | How to reannotate Diagnose's output
-  (Annotation -> ann) ->
+  Pretty msg =>
   -- | The content of the file the reports are for
   FileMap ->
   -- | Should we print paths in unicode?
@@ -204,9 +203,9 @@ prettyReport ::
   -- | The number of spaces each TAB character will span
   Int ->
   -- | The whole report to output
-  Report (Doc ann) ->
-  Doc ann
-prettyReport sty fileContent withUnicode tabSize (Report isError code message markers hints) =
+  Report msg ->
+  Doc Annotation
+prettyReport fileContent withUnicode tabSize (Report isError code message markers hints) =
   let sortedMarkers = List.sortOn (fst . begin . fst) markers
       -- sort the markers so that the first lines of the reports are the first lines of the file
 
@@ -218,7 +217,7 @@ prettyReport sty fileContent withUnicode tabSize (Report isError code message ma
 
       header =
         annotate
-          (sty (KindColor isError))
+          (KindColor isError)
           ( lbracket
               <> ( if isError
                      then "error"
@@ -226,7 +225,7 @@ prettyReport sty fileContent withUnicode tabSize (Report isError code message ma
                  )
               <> case code of
                 Nothing -> rbracket
-                Just code -> space <> code <> rbracket
+                Just code -> space <> pretty code <> rbracket
           )
    in {-
               A report is of the form:
@@ -241,19 +240,19 @@ prettyReport sty fileContent withUnicode tabSize (Report isError code message ma
               (6)    -------+
       -}
 
-      {- (1) -} header <> colon <+> align message
-        <> {- (2), (3), (4) -} foldMap (uncurry (prettySubReport sty fileContent withUnicode isError tabSize maxLineNumberLength)) groupedMarkers
+      {- (1) -} header <> colon <+> align (pretty message)
+        <> {- (2), (3), (4) -} fold (uncurry (prettySubReport fileContent withUnicode isError tabSize maxLineNumberLength) <$> groupedMarkers)
         <> {- (5) -} ( if
                            | null hints && null markers -> mempty
                            | null hints -> mempty
-                           | otherwise -> hardline <+> reAnnotate sty (dotPrefix maxLineNumberLength withUnicode)
+                           | otherwise -> hardline <+> dotPrefix maxLineNumberLength withUnicode
                      )
-        <> prettyAllHints sty hints maxLineNumberLength withUnicode
+        <> prettyAllHints hints maxLineNumberLength withUnicode
         <> hardline
         <> {- (6) -} ( if null markers && null hints
                          then mempty
                          else
-                           annotate (sty RuleColor) (pad (maxLineNumberLength + 2) (if withUnicode then '─' else '-') mempty <> if withUnicode then "╯" else "+")
+                           annotate RuleColor (pad (maxLineNumberLength + 2) (if withUnicode then '─' else '-') mempty <> if withUnicode then "╯" else "+")
                              <> hardline
                      )
 
@@ -329,6 +328,7 @@ ellipsisPrefix ::
 ellipsisPrefix leftLen withUnicode = pad leftLen ' ' mempty <> annotate RuleColor (if withUnicode then space <> "⋮" else "...")
 
 groupMarkersPerFile ::
+  Pretty msg =>
   [(Position, Marker msg)] ->
   [(Bool, [(Position, Marker msg)])]
 groupMarkersPerFile [] = []
@@ -352,8 +352,7 @@ groupMarkersPerFile markers =
 
 -- | Prettyprint a sub-report, which is a part of the report spanning across a single file
 prettySubReport ::
-  -- | How to reannotate Diagnose's output
-  (Annotation -> ann) ->
+  Pretty msg =>
   -- | The content of files in the diagnostics
   FileMap ->
   -- | Is the output done with Unicode characters?
@@ -367,9 +366,9 @@ prettySubReport ::
   -- | Is this sub-report the first one in the list?
   Bool ->
   -- | The list of line-ordered markers appearing in a single file
-  [(Position, Marker (Doc ann))] ->
-  Doc ann
-prettySubReport sty fileContent withUnicode isError tabSize maxLineNumberLength isFirst markers =
+  [(Position, Marker msg)] ->
+  Doc Annotation
+prettySubReport fileContent withUnicode isError tabSize maxLineNumberLength isFirst markers =
   let (markersPerLine, multilineMarkers) = splitMarkersPerLine markers
       -- split the list on whether markers are multiline or not
 
@@ -391,10 +390,10 @@ prettySubReport sty fileContent withUnicode isError tabSize maxLineNumberLength 
                 <> annotate RuleColor (if withUnicode then "┼──▶" else "+-->")
         )
           <+> annotate FileColor reportFile
-   in {- (2) -} hardline <> reAnnotate sty fileMarker
+   in {- (2) -} hardline <> fileMarker
         <> hardline
-          <+> {- (3) -}  {- (3) -} reAnnotate sty (pipePrefix maxLineNumberLength withUnicode)
-        <> {- (4) -} prettyAllLines sty fileContent withUnicode isError tabSize maxLineNumberLength sortedMarkersPerLine multilineMarkers allLineNumbers
+          <+> {- (3) -} pipePrefix maxLineNumberLength withUnicode
+        <> {- (4) -} prettyAllLines fileContent withUnicode isError tabSize maxLineNumberLength sortedMarkersPerLine multilineMarkers allLineNumbers
 
 isThisMarker :: Marker msg -> Bool
 isThisMarker (This _) = True
@@ -411,30 +410,30 @@ splitMarkersPerLine (m@(Position {..}, _) : ms) =
 
 -- |
 prettyAllLines ::
-  (Annotation -> ann) ->
+  Pretty msg =>
   FileMap ->
   Bool ->
   Bool ->
   -- | The number of spaces each TAB character will span
   Int ->
   Int ->
-  [(Int, [(Position, Marker (Doc ann))])] ->
-  [(Position, Marker (Doc ann))] ->
+  [(Int, [(Position, Marker msg)])] ->
+  [(Position, Marker msg)] ->
   [Int] ->
-  Doc ann
-prettyAllLines sty files withUnicode isError tabSize leftLen inline multiline lineNumbers =
+  Doc Annotation
+prettyAllLines files withUnicode isError tabSize leftLen inline multiline lineNumbers =
   case lineNumbers of
     [] ->
       showMultiline True multiline
     [l] ->
       let (ms, doc) = showForLine True l
        in doc
-            <> prettyAllLines sty files withUnicode isError tabSize leftLen inline ms []
+            <> prettyAllLines files withUnicode isError tabSize leftLen inline ms []
     l1 : l2 : ls ->
       let (ms, doc) = showForLine False l1
        in doc
-            <> (if l2 /= l1 + 1 then hardline <+> reAnnotate sty (dotPrefix leftLen withUnicode) else mempty)
-            <> prettyAllLines sty files withUnicode isError tabSize leftLen inline ms (l2 : ls)
+            <> (if l2 /= l1 + 1 then hardline <+> dotPrefix leftLen withUnicode else mempty)
+            <> prettyAllLines files withUnicode isError tabSize leftLen inline ms (l2 : ls)
   where
     showForLine isLastLine line =
       {-
@@ -482,12 +481,12 @@ prettyAllLines sty files withUnicode isError tabSize leftLen inline multiline li
           allInlineMarkersInLine' = filter ((/=) Blank . snd) allInlineMarkersInLine
           allMultilineMarkersSpanningLine' = filter ((/=) Blank . snd) allMultilineMarkersSpanningLine
 
-          (widths, renderedCode) = getLine_ sty files (allInlineMarkersInLine <> allMultilineMarkersInLine <> allMultilineMarkersSpanningLine') line tabSize isError
+          (widths, renderedCode) = getLine_ files (allInlineMarkersInLine <> allMultilineMarkersInLine <> allMultilineMarkersSpanningLine') line tabSize isError
        in ( otherMultilines,
             hardline
-              <> {- (1) -} reAnnotate sty (linePrefix leftLen line withUnicode <+> additionalPrefix)
+              <> {- (1) -} linePrefix leftLen line withUnicode <+> additionalPrefix
               <> renderedCode
-              <> {- (2) -} showAllMarkersInLine sty (not $ null multiline) inSpanOfMultiline colorOfFirstMultilineMarker withUnicode isError leftLen widths allInlineMarkersInLine'
+              <> {- (2) -} showAllMarkersInLine (not $ null multiline) inSpanOfMultiline colorOfFirstMultilineMarker withUnicode isError leftLen widths allInlineMarkersInLine'
               <> showMultiline (isLastLine || List.safeLast multilineEndingOnLine == List.safeLast multiline) multilineEndingOnLine
           )
 
@@ -496,18 +495,18 @@ prettyAllLines sty files withUnicode isError tabSize leftLen inline multiline li
       let colorOfFirstMultilineMarker = markerColor isError . snd <$> List.safeHead multiline
           -- take the color of the last multiline marker in case we need to add additional bars
 
-          prefix = reAnnotate sty $ hardline <+> dotPrefix leftLen withUnicode <> space
+          prefix = hardline <+> dotPrefix leftLen withUnicode <> space
 
-          prefixWithBar color = prefix <> maybe id (annotate . sty) color (if withUnicode then "│ " else "| ")
+          prefixWithBar color = prefix <> maybe id annotate color (if withUnicode then "│ " else "| ")
 
           showMultilineMarkerMessage (_, Blank) _ = mempty
           showMultilineMarkerMessage (_, marker) isLast =
-            annotate (sty (markerColor isError marker)) $
+            annotate (markerColor isError marker) $
               ( if isLast && isLastMultiline
                   then if withUnicode then "╰╸ " else "`- "
                   else if withUnicode then "├╸ " else "|- "
               )
-                <> replaceLinesWith (if isLast then prefix <> "   " else prefixWithBar (Just $ markerColor isError marker) <> space) (markerMessage marker)
+                <> replaceLinesWith (if isLast then prefix <> "   " else prefixWithBar (Just $ markerColor isError marker) <> space) (pretty $ markerMessage marker)
 
           showMultilineMarkerMessages [] = []
           showMultilineMarkerMessages [m] = [showMultilineMarkerMessage m True]
@@ -516,18 +515,17 @@ prettyAllLines sty files withUnicode isError tabSize leftLen inline multiline li
 
 -- |
 getLine_ ::
-  (Annotation -> ann) ->
   FileMap ->
   [(Position, Marker msg)] ->
   Int ->
   Int ->
   Bool ->
-  (WidthTable, Doc ann)
-getLine_ sty files markers line tabSize isError =
+  (WidthTable, Doc Annotation)
+getLine_ files markers line tabSize isError =
   case safeArrayIndex (line - 1) =<< (HashMap.!?) files . file . fst =<< List.safeHead markers of
     Nothing ->
       ( mkWidthTable "",
-        annotate (sty NoLineColor) "<no line>"
+        annotate NoLineColor "<no line>"
       )
     Just code ->
       ( mkWidthTable code,
@@ -542,8 +540,8 @@ getLine_ sty files markers line tabSize isError =
                       || (el == line && n < ec)
                       || (bl < line && el > line)
            in maybe
-                (annotate (sty CodeStyle))
-                ((\m -> annotate (sty . MarkerStyle $ markerColor isError m)) . snd)
+                (annotate CodeStyle)
+                ((\m -> annotate (MarkerStyle $ markerColor isError m)) . snd)
                 (List.safeHead colorizingMarkers)
                 cdoc
       )
@@ -556,16 +554,16 @@ getLine_ sty files markers line tabSize isError =
     mkWidthTable s = listArray (1, length s) (ifTab tabSize wcwidth <$> s)
 
 -- |
-showAllMarkersInLine :: (Annotation -> ann) -> Bool -> Bool -> (Doc Annotation -> Doc Annotation) -> Bool -> Bool -> Int -> WidthTable -> [(Position, Marker (Doc ann))] -> Doc ann
-showAllMarkersInLine _ _ _ _ _ _ _ _ [] = mempty
-showAllMarkersInLine sty hasMultilines inSpanOfMultiline colorMultilinePrefix withUnicode isError leftLen widths ms =
+showAllMarkersInLine :: Pretty msg => Bool -> Bool -> (Doc Annotation -> Doc Annotation) -> Bool -> Bool -> Int -> WidthTable -> [(Position, Marker msg)] -> Doc Annotation
+showAllMarkersInLine _ _ _ _ _ _ _ [] = mempty
+showAllMarkersInLine hasMultilines inSpanOfMultiline colorMultilinePrefix withUnicode isError leftLen widths ms =
   let maxMarkerColumn = snd $ end $ fst $ List.last $ List.sortOn (snd . end . fst) ms
       specialPrefix
         | inSpanOfMultiline = colorMultilinePrefix (if withUnicode then "│ " else "| ") <> space
         | hasMultilines = colorMultilinePrefix "  " <> space
         | otherwise = mempty
    in -- get the maximum end column, so that we know when to stop looking for other markers on the same line
-      hardline <+> reAnnotate sty (dotPrefix leftLen withUnicode <+> if List.null ms then mempty else specialPrefix <> showMarkers 1 maxMarkerColumn) <> showMessages specialPrefix ms maxMarkerColumn
+      hardline <+> dotPrefix leftLen withUnicode <+> (if List.null ms then mempty else specialPrefix <> showMarkers 1 maxMarkerColumn <> showMessages specialPrefix ms maxMarkerColumn)
   where
     widthAt i = 0 `fromMaybe` safeArrayIndex i widths
     widthsBetween start end =
@@ -607,14 +605,14 @@ showAllMarkersInLine sty hasMultilines inSpanOfMultiline colorMultilinePrefix wi
             lineStart pipes =
               let (n, docs) = allColumns 1 $ List.sortOn (snd . begin . fst) pipes
                   numberOfSpaces = widthsBetween n bc
-               in reAnnotate sty (dotPrefix leftLen withUnicode <+> specialPrefix) <> fold docs <> pretty (replicate numberOfSpaces ' ')
+               in dotPrefix leftLen withUnicode <+> specialPrefix <> fold docs <> pretty (replicate numberOfSpaces ' ')
             -- the start of the line contains the "dot"-prefix as well as all the pipes for all the still not rendered marker messages
 
             prefix =
               let (pipesBefore, pipesAfter) = List.partition ((< bc) . snd . begin . fst) nubbedPipes
                   -- split the list so that all pipes before can have `|`s but pipes after won't
 
-                  pipesBeforeRendered = pipesBefore <&> second \marker -> annotate (sty (markerColor isError marker)) (if withUnicode then "│" else "|")
+                  pipesBeforeRendered = pipesBefore <&> second \marker -> annotate (markerColor isError marker) (if withUnicode then "│" else "|")
                   -- pre-render pipes which are before because they will be shown
 
                   lastBeginPosition = snd . begin . fst <$> List.safeLast (List.sortOn (snd . begin . fst) pipesAfter)
@@ -636,13 +634,13 @@ showAllMarkersInLine sty hasMultilines inSpanOfMultiline colorMultilinePrefix wi
                   bc' = bc + lineLen + 2
                   pipesBeforeMessageStart = List.filter ((< bc') . snd . begin . fst) pipesAfter
                   -- consider pipes before, as well as pipes which came before the text rectangle bounds
-                  pipesBeforeMessageRendered = (pipesBefore <> pipesBeforeMessageStart) <&> second \marker -> annotate (sty (markerColor isError marker)) (if withUnicode then "│" else "|")
+                  pipesBeforeMessageRendered = (pipesBefore <> pipesBeforeMessageStart) <&> second \marker -> annotate (markerColor isError marker) (if withUnicode then "│" else "|")
                in -- also pre-render pipes which are before the message text bounds, because they will be shown if the message is on
                   -- multiple lines
 
                   lineStart pipesBeforeRendered
-                    <> annotate (sty (markerColor isError msg)) (currentPipe <> pretty (replicate lineLen lineChar) <> pointChar)
-                    <+> annotate (sty (markerColor isError msg)) (replaceLinesWith (hardline <+> lineStart pipesBeforeMessageRendered <+> if List.null pipesBeforeMessageStart then "  " else " ") $ markerMessage msg)
+                    <> annotate (markerColor isError msg) (currentPipe <> pretty (replicate lineLen lineChar) <> pointChar)
+                    <+> annotate (markerColor isError msg) (replaceLinesWith (hardline <+> lineStart pipesBeforeMessageRendered <+> if List.null pipesBeforeMessageStart then "  " else " ") $ pretty $ markerMessage msg)
          in hardline <+> prefix <> showMessages specialPrefix pipes lineLen
 
 -- WARN: uses the internal of the library
@@ -691,16 +689,16 @@ markerMessage Blank = undefined
 {-# INLINE markerMessage #-}
 
 -- | Pretty prints all hints.
-prettyAllHints :: (Annotation -> ann) -> [Note (Doc ann)] -> Int -> Bool -> Doc ann
-prettyAllHints _ [] _ _ = mempty
-prettyAllHints sty (h : hs) leftLen withUnicode =
+prettyAllHints :: Pretty msg => [Note msg] -> Int -> Bool -> Doc Annotation
+prettyAllHints [] _ _ = mempty
+prettyAllHints (h : hs) leftLen withUnicode =
   {-
         A hint is composed of:
         (1)         : Hint: <hint message>
   -}
-  let prefix = hardline <+> reAnnotate sty (pipePrefix leftLen withUnicode)
-   in prefix <+> annotate (sty HintColor) (notePrefix h <+> replaceLinesWith (prefix <+> "      ") (noteMessage h))
-        <> prettyAllHints sty hs leftLen withUnicode
+  let prefix = hardline <+> pipePrefix leftLen withUnicode
+   in prefix <+> annotate HintColor (notePrefix h <+> replaceLinesWith (prefix <+> "      ") (pretty $ noteMessage h))
+        <> prettyAllHints hs leftLen withUnicode
   where
     notePrefix (Note _) = "Note:"
     notePrefix (Hint _) = "Hint:"

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -53,7 +53,7 @@ import qualified Data.Text as Text
 import Error.Diagnose.Position
 import Error.Diagnose.Style (Annotation (..))
 import Prettyprinter (Doc, Pretty (..), align, annotate, colon, hardline, lbracket, rbracket, space, width, (<+>), reAnnotate)
-import Prettyprinter.Internal (Doc (..))
+import Prettyprinter.Internal (Doc (..), textSpaces)
 import Data.Bool (bool)
 
 type FileMap = HashMap FilePath (Array Int String)
@@ -653,7 +653,8 @@ replaceLinesWith repl (Text _ s) =
    in mconcat (List.intersperse repl lines)
 replaceLinesWith repl (FlatAlt f d) = FlatAlt (replaceLinesWith repl f) (replaceLinesWith repl d)
 replaceLinesWith repl (Cat c d) = Cat (replaceLinesWith repl c) (replaceLinesWith repl d)
-replaceLinesWith repl (Nest n d) = Nest n (replaceLinesWith repl d)
+-- We need to push the nesting past our line prefix
+replaceLinesWith repl (Nest n d) = replaceLinesWith (repl <> pretty (textSpaces n)) d
 replaceLinesWith repl (Union c d) = Union (replaceLinesWith repl c) (replaceLinesWith repl d)
 replaceLinesWith repl (Column f) = Column (replaceLinesWith repl . f)
 replaceLinesWith repl (Nesting f) = Nesting (replaceLinesWith repl . f)

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -67,6 +70,7 @@ data Report msg
       -- ^ A map associating positions with marker to show under the source code.
       [Note msg]
       -- ^ A list of notes to add at the end of the report.
+  deriving (Functor, Foldable, Traversable)
 
 -- | Pattern synonym for a warning report.
 pattern Warn :: Maybe msg -> msg -> [(Position, Marker msg)] -> [Note msg] -> Report msg
@@ -120,6 +124,7 @@ data Marker msg
     Maybe msg
   | -- | An empty marker, whose sole purpose is to include a line of code in the report without markers under.
     Blank
+  deriving (Functor, Foldable, Traversable)
 
 instance Eq (Marker msg) where
   This _ == This _ = True
@@ -147,6 +152,7 @@ data Note msg
     Note msg
   | -- | A hint, to propose potential fixes or help towards fixing the issue.
     Hint msg
+  deriving (Functor, Foldable, Traversable)
 
 #ifdef USE_AESON
 instance ToJSON msg => ToJSON (Note msg) where

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -15,9 +15,13 @@ module Error.Diagnose.Style
 
     -- * Default style specification
     defaultStyle,
+
+    -- * Re-exports
+    reAnnotate,
   )
 where
 
+import Prettyprinter (Doc, reAnnotate)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), bold, color, colorDull)
 
 -- $defining_new_styles

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveTraversable #-}
 
 -- |

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 
 -- |
 -- Module      : Error.Diagnose.Style
@@ -71,7 +73,7 @@ data Annotation a
     CodeStyle
   | -- | Something else, could be provided by the user
     OtherStyle a
-  deriving (Functor)
+  deriving (Functor, Foldable, Traversable)
 
 -- | A style is a function which can be applied using 'reAnnotate'.
 --

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveFunctor #-}
+
 -- |
 -- Module      : Error.Diagnose.Style
 -- Description : Custom style definitions
@@ -37,7 +39,7 @@ import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), bold, color, colorD
 -- For simplicity's sake, a default style is given as 'defaultStyle'.
 
 -- | Some annotations as placeholders for colors in a 'Doc'.
-data Annotation
+data Annotation a
   = -- | The color of 'Error.Diagnose.Report.This' markers, depending on whether the report is an error
     --   report or a warning report.
     ThisColor
@@ -63,15 +65,18 @@ data Annotation
   | -- | Additional style to apply to marker rules (e.g. bold) on top of some
     --   already processed color annotation.
     MarkerStyle
-      Annotation
+      (Annotation a)
   | -- | The color of the code when no marker is present.
     CodeStyle
+  | -- | Something else, could be provided by the user
+    OtherStyle a
+  deriving (Functor)
 
 -- | A style is a function which can be applied using 'reAnnotate'.
 --
 --   It transforms a 'Doc'ument containing 'Annotation's into a 'Doc'ument containing
 --   color information.
-type Style = Annotation -> AnsiStyle
+type Style a = Annotation a -> AnsiStyle
 
 -------------------------------------------
 
@@ -86,7 +91,7 @@ type Style = Annotation -> AnsiStyle
 --   * File names are output in dull green
 --   * The @[error]@/@[warning]@ at the top is colored in red for errors and yellow for warnings
 --   * The code is output in normal white
-defaultStyle :: Style
+defaultStyle :: Style AnsiStyle
 defaultStyle = \case
     ThisColor isError -> color if isError then Red else Yellow
     MaybeColor -> color Magenta
@@ -102,3 +107,4 @@ defaultStyle = \case
             then ann
             else bold <> ann
     CodeStyle -> color White
+    OtherStyle s -> s

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -13,13 +13,9 @@ module Error.Diagnose.Style
 
     -- * Default style specification
     defaultStyle,
-
-    -- * Re-exports
-    reAnnotate,
   )
 where
 
-import Prettyprinter (Doc, reAnnotate)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), bold, color, colorDull)
 
 -- $defining_new_styles
@@ -75,7 +71,7 @@ data Annotation
 --
 --   It transforms a 'Doc'ument containing 'Annotation's into a 'Doc'ument containing
 --   color information.
-type Style = Doc Annotation -> Doc AnsiStyle
+type Style = Annotation -> AnsiStyle
 
 -------------------------------------------
 
@@ -91,20 +87,18 @@ type Style = Doc Annotation -> Doc AnsiStyle
 --   * The @[error]@/@[warning]@ at the top is colored in red for errors and yellow for warnings
 --   * The code is output in normal white
 defaultStyle :: Style
-defaultStyle = reAnnotate style
-  where
-    style = \case
-      ThisColor isError -> color if isError then Red else Yellow
-      MaybeColor -> color Magenta
-      WhereColor -> colorDull Blue
-      HintColor -> color Cyan
-      FileColor -> bold <> colorDull Green
-      RuleColor -> bold <> color Black
-      KindColor isError -> bold <> style (ThisColor isError)
-      NoLineColor -> bold <> colorDull Magenta
-      MarkerStyle st ->
-        let ann = style st
-         in if ann == style CodeStyle
-              then ann
-              else bold <> ann
-      CodeStyle -> color White
+defaultStyle = \case
+    ThisColor isError -> color if isError then Red else Yellow
+    MaybeColor -> color Magenta
+    WhereColor -> colorDull Blue
+    HintColor -> color Cyan
+    FileColor -> bold <> colorDull Green
+    RuleColor -> bold <> color Black
+    KindColor isError -> bold <> defaultStyle (ThisColor isError)
+    NoLineColor -> bold <> colorDull Magenta
+    MarkerStyle st ->
+      let ann = defaultStyle st
+       in if ann == defaultStyle CodeStyle
+            then ann
+            else bold <> ann
+    CodeStyle -> color White

--- a/src/Error/Diagnose/Style.hs
+++ b/src/Error/Diagnose/Style.hs
@@ -13,15 +13,12 @@ module Error.Diagnose.Style
     Style,
     -- $defining_new_styles
 
-    -- * Default style specification
+    -- * Styles
     defaultStyle,
-
-    -- * Re-exports
-    reAnnotate,
+    unadornedStyle,
   )
 where
 
-import Prettyprinter (Doc, reAnnotate)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), bold, color, colorDull)
 
 -- $defining_new_styles
@@ -83,6 +80,10 @@ data Annotation a
 type Style a = Annotation a -> AnsiStyle
 
 -------------------------------------------
+
+-- | A style which disregards all annotations
+unadornedStyle :: Style a
+unadornedStyle = const mempty
 
 -- | The default style for diagnostics, where:
 --

--- a/test/megaparsec/Repro6.hs
+++ b/test/megaparsec/Repro6.hs
@@ -44,12 +44,12 @@ main = do
                 content3
 
   case res1 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
     Right res -> print res
   case res2 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
     Right res -> print res
   putStrLn "------------- res3 ----------------"
   case res3 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
     Right res -> print res

--- a/test/megaparsec/Repro6.hs
+++ b/test/megaparsec/Repro6.hs
@@ -44,12 +44,12 @@ main = do
                 content3
 
   case res1 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
     Right res -> print res
   case res2 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
     Right res -> print res
   putStrLn "------------- res3 ----------------"
   case res3 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
     Right res -> print res

--- a/test/megaparsec/Spec.hs
+++ b/test/megaparsec/Spec.hs
@@ -29,10 +29,10 @@ main = do
       res2 = first (errorDiagnosticFromBundle Nothing "Parse error on input" Nothing) $ MP.runParser @Void (MP.some MP.decimal <* MP.eof) filename content2
 
   case res1 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
     Right res -> print res
   case res2 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
     Right res -> print res
 
   putStrLn "---------------------------------------------------"

--- a/test/megaparsec/Spec.hs
+++ b/test/megaparsec/Spec.hs
@@ -29,11 +29,11 @@ main = do
       res2 = first (errorDiagnosticFromBundle Nothing "Parse error on input" Nothing) $ MP.runParser @Void (MP.some MP.decimal <* MP.eof) filename content2
 
   case res1 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
-    Right res -> print res
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Right res -> print @[Integer] res
   case res2 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
-    Right res -> print res
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Right res -> print @[Integer] res
 
   putStrLn "---------------------------------------------------"
 

--- a/test/megaparsec/Spec.hs
+++ b/test/megaparsec/Spec.hs
@@ -16,7 +16,6 @@ import Error.Diagnose.Compat.Megaparsec
 import Instances ()
 import qualified Repro6
 import qualified Text.Megaparsec as MP
-import qualified Text.Megaparsec.Char as MP
 import qualified Text.Megaparsec.Char.Lexer as MP
 
 main :: IO ()

--- a/test/parsec/Repro2.hs
+++ b/test/parsec/Repro2.hs
@@ -29,8 +29,8 @@ parser2 = op' "\\" *> letter
 
 main :: IO ()
 main = do
-  either (printDiagnostic stderr True True 4 defaultStyle) print $ diagParse parser1 "issues/2.txt" "\\1"
-  either (printDiagnostic stderr True True 4 defaultStyle) print $ diagParse parser2 "issues/2.txt" "\\1"
+  either (printDiagnostic stderr True 4 defaultStyle) print $ diagParse parser1 "issues/2.txt" "\\1"
+  either (printDiagnostic stderr True 4 defaultStyle) print $ diagParse parser2 "issues/2.txt" "\\1"
 
 -- smaller example
 op' :: String -> Parser String

--- a/test/parsec/Repro2.hs
+++ b/test/parsec/Repro2.hs
@@ -29,8 +29,8 @@ parser2 = op' "\\" *> letter
 
 main :: IO ()
 main = do
-  either (printDiagnostic stderr True 4 defaultStyle) print $ diagParse parser1 "issues/2.txt" "\\1"
-  either (printDiagnostic stderr True 4 defaultStyle) print $ diagParse parser2 "issues/2.txt" "\\1"
+  either (printDiagnostic stderr WithUnicode (TabSize 4) defaultStyle) print $ diagParse parser1 "issues/2.txt" "\\1"
+  either (printDiagnostic stderr WithUnicode (TabSize 4) defaultStyle) print $ diagParse parser2 "issues/2.txt" "\\1"
 
 -- smaller example
 op' :: String -> Parser String

--- a/test/parsec/Spec.hs
+++ b/test/parsec/Spec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 {-# OPTIONS -Wno-orphans #-}
 

--- a/test/parsec/Spec.hs
+++ b/test/parsec/Spec.hs
@@ -32,13 +32,13 @@ main = do
       res3 = first (errorDiagnosticFromParseError Nothing "Parse error on input" Nothing) $ P.parse (test1 <* P.eof) filename content3
 
   case res1 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
     Right res -> print res
   case res2 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
     Right res -> print res
   case res3 of
-    Left diag -> printDiagnostic stdout True True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
     Right res -> print res
 
   -- all issue reproduction

--- a/test/parsec/Spec.hs
+++ b/test/parsec/Spec.hs
@@ -32,13 +32,13 @@ main = do
       res3 = first (errorDiagnosticFromParseError Nothing "Parse error on input" Nothing) $ P.parse (test1 <* P.eof) filename content3
 
   case res1 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content1) :: Diagnostic String)
     Right res -> print res
   case res2 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content2) :: Diagnostic String)
     Right res -> print res
   case res3 of
-    Left diag -> printDiagnostic stdout True 4 defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
+    Left diag -> printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle (addFile diag filename (Text.unpack content3) :: Diagnostic String)
     Right res -> print res
 
   -- all issue reproduction

--- a/test/rendering/Spec.hs
+++ b/test/rendering/Spec.hs
@@ -17,6 +17,8 @@ import Error.Diagnose
     defaultStyle,
     printDiagnostic,
     stdout,
+    WithUnicode (..),
+    TabSize (..),
   )
 import System.IO (hPutStrLn)
 
@@ -77,9 +79,9 @@ main = do
   let diag = HashMap.foldlWithKey' addFile (foldl addReport def reports) files
 
   hPutStrLn stdout "\n\nWith unicode: ─────────────────────────\n"
-  printDiagnostic stdout True 4 defaultStyle diag
+  printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle diag
   hPutStrLn stdout "\n\nWithout unicode: ----------------------\n"
-  printDiagnostic stdout False 4 defaultStyle diag
+  printDiagnostic stdout WithoutUnicode (TabSize 4) defaultStyle diag
 #ifdef USE_AESON
   hPutStrLn stdout "\n\nAs JSON: ------------------------------\n"
   BS.hPutStr stdout (diagnosticToJson diag)

--- a/test/rendering/Spec.hs
+++ b/test/rendering/Spec.hs
@@ -77,9 +77,9 @@ main = do
   let diag = HashMap.foldlWithKey' addFile (foldl addReport def reports) files
 
   hPutStrLn stdout "\n\nWith unicode: ─────────────────────────\n"
-  printDiagnostic stdout True True 4 defaultStyle diag
+  printDiagnostic stdout True 4 defaultStyle diag
   hPutStrLn stdout "\n\nWithout unicode: ----------------------\n"
-  printDiagnostic stdout False True 4 defaultStyle diag
+  printDiagnostic stdout False 4 defaultStyle diag
 #ifdef USE_AESON
   hPutStrLn stdout "\n\nAs JSON: ------------------------------\n"
   BS.hPutStr stdout (diagnosticToJson diag)

--- a/test/rendering/Spec.hs
+++ b/test/rendering/Spec.hs
@@ -17,6 +17,7 @@ import Error.Diagnose
     defaultStyle,
     printDiagnostic,
     stdout,
+    diagnosticToJson,
     WithUnicode (..),
     TabSize (..),
   )

--- a/test/rendering/Spec.hs
+++ b/test/rendering/Spec.hs
@@ -25,7 +25,8 @@ import Error.Diagnose
     TabSize (..),
   )
 import System.IO (hPutStrLn)
-import Prettyprinter (Doc, annotate, pretty, hsep, indent, vsep, nest)
+import Prettyprinter (Doc, annotate, pretty, hsep, indent, vsep, nest, (<+>), align, list)
+import Prettyprinter.Util (reflow)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), color, bold, italicized, underlined)
 import Data.Traversable (mapAccumL)
 import Data.Functor.Compose (Compose(..))
@@ -162,7 +163,7 @@ nestingReport =
     (nest 4 $ vsep ["Nest...", "foo", "bar", "baz"])
     [ (Position (1, 15) (1, 16) "test.zc", Maybe a)
     ]
-    [Note b]
+    [Note b, Hint c]
  where
   a =
     nest 3 $
@@ -172,12 +173,29 @@ nestingReport =
         , "'My favourite day,' said Pooh."
         ]
   b =
-    foldr1 (\p q -> nest 2 (vsep [p, q]))
-        [ "It's a very funny thought that, if Bears were Bees,"
-        , "They'd build their nests at the bottom of trees."
-        , "And that being so (if the Bees were Bears),"
-        , "We shouldn't have to climb up all these stairs."
-        ]
+    foldr1
+      (\p q -> nest 2 (vsep [p, q]))
+      [ "It's a very funny thought that, if Bears were Bees,"
+      , "They'd build their nests at the bottom of trees."
+      , "And that being so (if the Bees were Bears),"
+      , "We shouldn't have to climb up all these stairs."
+      ]
+  c =
+    "The elements:"
+      <+> align
+        ( list
+            [ "antimony"
+            , "arsenic"
+            , "aluminum"
+            , "selenium"
+            , "hydrogen"
+            , "oxygen"
+            , "nitrogen"
+            , "rhenium"
+            , align $ reflow "And there may be many others, but they haven't been discovered"
+            ]
+        )
+
 
 errorNoMarkersNoHints :: Report String
 errorNoMarkersNoHints =


### PR DESCRIPTION
I originally implemented it with the user supplying a function `Annotation -> ann` along with their `Doc ann`s. This made it certain that Diagnose wasn't messing with the user's types, however the implementation was much more clunky so I went with the simpler solution of adding another case to `Annotation`.

Here are two examples of: colorful user portions of messages and newlines + indentation in one of the messages

![image](https://github.com/Mesabloo/diagnose/assets/857308/74df7ed5-3dc7-4e83-b01d-d239bcdc3d56)

Also included:
- Some qol instances: Functor, Foldable, Traversable instances where appropriate, Eq and Ord for Note (https://github.com/Mesabloo/diagnose/pull/17)
- making withUnicode and tabSize their own types to make the `printDiagnostic` interface slightly less difficult.
- Major version bump because of that breaking change.