### PR TITLE
Use < 2.2 as upper bound for text

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -72,7 +72,7 @@ library
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && <=2.0
+    , text >=1.0.0.0 && < 2.1
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
@@ -199,7 +199,7 @@ test-suite diagnose-rendering-tests
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && <=2.0
+    , text >=1.0.0.0 && < 2.1
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010

--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -72,7 +72,7 @@ library
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && < 2.1
+    , text >=1.0.0.0 && < 2.2
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
@@ -199,7 +199,7 @@ test-suite diagnose-rendering-tests
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && < 2.1
+    , text >=1.0.0.0 && < 2.2
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ dependencies:
 - prettyprinter-ansi-terminal >= 1.1.2 && < 2
 - unordered-containers >= 0.2.11 && < 0.3
 - wcwidth >= 0.0.1 && <1
-- text >= 1.0.0.0 && <= 2.0
+- text >= 1.0.0.0 && < 2.1
 # ^^^ This is unfortunately required, but as 'prettyprinter' already depends on it, it will already have been fetched
 # into the local cache anyway.
 

--- a/package.yaml
+++ b/package.yaml
@@ -16,7 +16,7 @@ dependencies:
 - prettyprinter-ansi-terminal >= 1.1.2 && < 2
 - unordered-containers >= 0.2.11 && < 0.3
 - wcwidth >= 0.0.1 && <1
-- text >= 1.0.0.0 && < 2.1
+- text >= 1.0.0.0 && < 2.2
 # ^^^ This is unfortunately required, but as 'prettyprinter' already depends on it, it will already have been fetched
 # into the local cache anyway.
 


### PR DESCRIPTION
It's a bit strange to have `<= 2.0` as the bound for `text` since it means that version `2.0` is allowed but not `2.0.1` or `2.0.2`.  I checked that `diagnose` builds cleanly and all the tests pass with both `text-2.0.2` and `text-2.1`.