### PR TITLE
remove `text` dependency

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -72,7 +72,6 @@ library
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && <=2.0
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
@@ -199,7 +198,6 @@ test-suite diagnose-rendering-tests
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , text >=1.0.0.0 && <=2.0
     , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -16,9 +16,6 @@ dependencies:
 - prettyprinter-ansi-terminal >= 1.1.2 && < 2
 - unordered-containers >= 0.2.11 && < 0.3
 - wcwidth >= 0.0.1 && <1
-- text >= 1.0.0.0 && <= 2.0
-# ^^^ This is unfortunately required, but as 'prettyprinter' already depends on it, it will already have been fetched
-# into the local cache anyway.
 
 default-extensions:
 - OverloadedStrings


### PR DESCRIPTION
`text` is only required for the `diagnose-megaparsec-tests` and `diagnose-parsec-tests` test suites.