### PR TITLE
chore: Remove transitive dependency on a few packages

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -67,7 +67,7 @@ library
   build-depends:
       array ==0.5.*
     , base >=4.7 && <5
-    , data-default >=0.7 && <1
+    , data-default-class >=0.1 && <1
     , dlist ==1.0.*
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
@@ -111,7 +111,7 @@ test-suite diagnose-megaparsec-tests
   build-depends:
       array ==0.5.*
     , base >=4.7 && <5
-    , data-default >=0.7 && <1
+    , data-default-class >=0.1 && <1
     , diagnose
     , dlist ==1.0.*
     , hashable >=1.3 && <2
@@ -152,7 +152,7 @@ test-suite diagnose-parsec-tests
   build-depends:
       array ==0.5.*
     , base >=4.7 && <5
-    , data-default >=0.7 && <1
+    , data-default-class >=0.1 && <1
     , diagnose
     , dlist ==1.0.*
     , hashable >=1.3 && <2
@@ -192,7 +192,7 @@ test-suite diagnose-rendering-tests
   build-depends:
       array ==0.5.*
     , base >=4.7 && <5
-    , data-default >=0.7 && <1
+    , data-default-class >=0.1 && <1
     , diagnose
     , dlist ==1.0.*
     , hashable >=1.3 && <2

--- a/src/Error/Diagnose/Position.hs
+++ b/src/Error/Diagnose/Position.hs
@@ -16,7 +16,7 @@ module Error.Diagnose.Position (Position (..)) where
 #ifdef USE_AESON
 import Data.Aeson (ToJSON(..), object, (.=))
 #endif
-import Data.Default (Default, def)
+import Data.Default.Class (Default, def)
 import Data.Hashable (Hashable)
 import GHC.Generics (Generic (..))
 import Prettyprinter (Pretty (..), colon)

--- a/src/Error/Diagnose/Report/Internal.hs
+++ b/src/Error/Diagnose/Report/Internal.hs
@@ -36,7 +36,7 @@ import qualified Data.Array.IArray as Array
 import Data.Array.Unboxed (Array, IArray, Ix, UArray, listArray, (!))
 import Data.Bifunctor (bimap, first, second)
 import Data.Char.WCWidth (wcwidth)
-import Data.Default (def)
+import Data.Default.Class (def)
 import Data.Foldable (fold)
 import Data.Function (on)
 import Data.Functor ((<&>), void)


### PR DESCRIPTION
By depending on data-default-class instead of
data-default, we remove these transitive
dependencies:

* data-default-instances-containers
* data-default-instances-dlist
* data-default-instances-old-locale
* containers
* old-locale

We retain dlist though, as we depend on it anyway.