### PR TITLE
Allow disabling `hashable` dependency

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -28,6 +28,11 @@ source-repository head
   type: git
   location: https://github.com/mesabloo/diagnose
 
+flag hashable
+  description: Enables the `Hashable Position` instance, and the `hashable` dependency.
+  manual: True
+  default: False
+
 flag json
   description: Allows exporting diagnostics as JSON. This is disabled by default as this relies on the very heavy dependency Aeson.
   manual: True
@@ -69,7 +74,6 @@ library
     , base >=4.7 && <5
     , data-default >=0.7 && <1
     , dlist ==1.0.*
-    , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , unordered-containers >=0.2.11 && <0.3
@@ -87,6 +91,10 @@ library
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
+  if flag(hashable)
+    cpp-options: -DHASHABLE
+    build-depends:
+        hashable >=1.3 && <2
   if flag(megaparsec-compat)
     exposed-modules:
         Error.Diagnose.Compat.Megaparsec
@@ -114,7 +122,6 @@ test-suite diagnose-megaparsec-tests
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*
-    , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , text >=1.2 && <3
@@ -133,6 +140,10 @@ test-suite diagnose-megaparsec-tests
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
+  if flag(hashable)
+    cpp-options: -DHASHABLE
+    build-depends:
+        hashable >=1.3 && <2
   if !(flag(megaparsec-compat))
     buildable: False
 
@@ -155,7 +166,6 @@ test-suite diagnose-parsec-tests
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*
-    , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , text >=1.2 && <3
@@ -174,6 +184,10 @@ test-suite diagnose-parsec-tests
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
+  if flag(hashable)
+    cpp-options: -DHASHABLE
+    build-depends:
+        hashable >=1.3 && <2
   if !(flag(parsec-compat))
     buildable: False
 
@@ -195,7 +209,6 @@ test-suite diagnose-rendering-tests
     , data-default >=0.7 && <1
     , diagnose
     , dlist ==1.0.*
-    , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , unordered-containers >=0.2.11 && <0.3
@@ -213,3 +226,7 @@ test-suite diagnose-rendering-tests
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
+  if flag(hashable)
+    cpp-options: -DHASHABLE
+    build-depends:
+        hashable >=1.3 && <2

--- a/package.yaml
+++ b/package.yaml
@@ -11,7 +11,6 @@ dependencies:
 - array >= 0.5 && < 0.6
 - data-default >= 0.7 && < 1
 - dlist >= 1.0 && < 1.1
-- hashable >= 1.3 && < 2
 - prettyprinter >= 1.7.0 && < 2
 - prettyprinter-ansi-terminal >= 1.1.2 && < 2
 - unordered-containers >= 0.2.11 && < 0.3
@@ -40,6 +39,10 @@ library:
     - Error.Diagnose.Compat.Parsec
 
 flags:
+  hashable:
+    description: "Enables the `Hashable Position` instance, and the `hashable` dependency."
+    manual: true
+    default: false
   json:
     description: "Allows exporting diagnostics as JSON.
       This is disabled by default as this relies on the very heavy dependency Aeson."
@@ -70,6 +73,11 @@ when:
   - condition: flag(parsec-compat)
     dependencies:
     - parsec >= 3.1.14
+  - condition: flag(hashable)
+    cpp-options:
+    - -DHASHABLE
+    dependencies:
+    - hashable >= 1.3 && < 2
 
 ghc-options:
 - -Wall

--- a/src/Error/Diagnose/Position.hs
+++ b/src/Error/Diagnose/Position.hs
@@ -17,7 +17,9 @@ module Error.Diagnose.Position (Position (..)) where
 import Data.Aeson (ToJSON(..), object, (.=))
 #endif
 import Data.Default (Default, def)
+#ifdef HASHABLE
 import Data.Hashable (Hashable)
+#endif
 import GHC.Generics (Generic (..))
 import Prettyprinter (Pretty (..), colon)
 
@@ -49,7 +51,9 @@ instance Pretty Position where
       at = pretty @String "@"
       dash = pretty @String "-"
 
+#ifdef HASHABLE
 instance Hashable Position
+#endif
 
 instance Default Position where
   def = Position (1, 1) (1, 1) "<no-file>"


### PR DESCRIPTION
Adds the `hashable` flag, which enables the
`Hashable Position` instance, and adds the
`hashable` dependency.

This defaults to false, as flags are trivial to update. If you want a zero friction upgrade, I can default it to true, but I'd rather not.