### PR TITLE
Remove (direct) dependency on containers

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -82,8 +82,7 @@ library
       , bytestring >=0.9 && <1
   if flag(megaparsec-compat)
     build-depends:
-        containers ==0.6.*
-      , megaparsec >=9.0.0
+        megaparsec >=9.0.0
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
@@ -128,8 +127,7 @@ test-suite diagnose-megaparsec-tests
       , bytestring >=0.9 && <1
   if flag(megaparsec-compat)
     build-depends:
-        containers ==0.6.*
-      , megaparsec >=9.0.0
+        megaparsec >=9.0.0
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
@@ -169,8 +167,7 @@ test-suite diagnose-parsec-tests
       , bytestring >=0.9 && <1
   if flag(megaparsec-compat)
     build-depends:
-        containers ==0.6.*
-      , megaparsec >=9.0.0
+        megaparsec >=9.0.0
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14
@@ -208,8 +205,7 @@ test-suite diagnose-rendering-tests
       , bytestring >=0.9 && <1
   if flag(megaparsec-compat)
     build-depends:
-        containers ==0.6.*
-      , megaparsec >=9.0.0
+        megaparsec >=9.0.0
   if flag(parsec-compat)
     build-depends:
         parsec >=3.1.14

--- a/package.yaml
+++ b/package.yaml
@@ -66,7 +66,6 @@ when:
   - condition: flag(megaparsec-compat)
     dependencies:
     - megaparsec >= 9.0.0
-    - containers == 0.6.*
   - condition: flag(parsec-compat)
     dependencies:
     - parsec >= 3.1.14

--- a/src/Error/Diagnose/Compat/Megaparsec.hs
+++ b/src/Error/Diagnose/Compat/Megaparsec.hs
@@ -24,8 +24,8 @@ module Error.Diagnose.Compat.Megaparsec
 where
 
 import Data.Bifunctor (second)
+import Data.Foldable (toList)
 import Data.Maybe (fromMaybe)
-import qualified Data.Set as Set (toList)
 import Data.String (IsString (..))
 import Error.Diagnose
 import Error.Diagnose.Compat.Hints (HasHints (..))
@@ -71,7 +71,7 @@ diagnosticFromBundle isError code msg (fromMaybe [] -> trivialHints) MP.ParseErr
     errorHints :: MP.ParseError s e -> [Note msg]
     errorHints MP.TrivialError {} = trivialHints
     errorHints (MP.FancyError _ errs) =
-      Set.toList errs >>= \case
+      toList errs >>= \case
         MP.ErrorCustom e -> hints e
         _ -> mempty
 


### PR DESCRIPTION
This removes the (+megaparsec-compat dependent)
direct dependency on containers.

This doesn't reduce the dependency footprint.