### PR TITLE
Remove dependency on unordered-containers

### DIFF
--- a/diagnose.cabal
+++ b/diagnose.cabal
@@ -72,7 +72,6 @@ library
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
   if flag(json)
@@ -118,7 +117,6 @@ test-suite diagnose-megaparsec-tests
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , text >=1.2 && <3
-    , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
   if flag(json)
@@ -159,7 +157,6 @@ test-suite diagnose-parsec-tests
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
     , text >=1.2 && <3
-    , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
   if flag(json)
@@ -198,7 +195,6 @@ test-suite diagnose-rendering-tests
     , hashable >=1.3 && <2
     , prettyprinter >=1.7.0 && <2
     , prettyprinter-ansi-terminal >=1.1.2 && <2
-    , unordered-containers >=0.2.11 && <0.3
     , wcwidth >=0.0.1 && <1
   default-language: Haskell2010
   if flag(json)

--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,6 @@ dependencies:
 - hashable >= 1.3 && < 2
 - prettyprinter >= 1.7.0 && < 2
 - prettyprinter-ansi-terminal >= 1.1.2 && < 2
-- unordered-containers >= 0.2.11 && < 0.3
 - wcwidth >= 0.0.1 && <1
 
 default-extensions:

--- a/src/Error/Diagnose/Diagnostic/Internal.hs
+++ b/src/Error/Diagnose/Diagnostic/Internal.hs
@@ -26,7 +26,6 @@ import Data.Array (listArray)
 import Data.DList (DList)
 import qualified Data.DList as DL
 import Data.Foldable (fold, toList)
-import qualified Data.HashMap.Lazy as HashMap
 import Data.List (intersperse)
 import Error.Diagnose.Report (Report)
 import Error.Diagnose.Report.Internal (FileMap, errorToWarning, prettyReport, warningToError, WithUnicode(..), TabSize(..))
@@ -58,7 +57,7 @@ instance Semigroup (Diagnostic msg) where
 #ifdef USE_AESON
 instance ToJSON msg => ToJSON (Diagnostic msg) where
   toJSON (Diagnostic reports files) =
-    object [ "files" .= fmap toJSONFile (fmap toList <$> (HashMap.toList files))
+    object [ "files" .= fmap toJSONFile (fmap toList <$> files)
            , "reports" .= reports
            ]
     where
@@ -175,7 +174,7 @@ addFile (Diagnostic reports files) path content =
   let fileLines = lines content
       lineCount = length fileLines
       lineArray = listArray (0, lineCount - 1) fileLines
-   in Diagnostic reports (HashMap.insert path lineArray files)
+   in Diagnostic reports ((path, lineArray) : files)
 {-# INLINE addFile #-}
 
 -- | Inserts a new report into a diagnostic.

--- a/test/rendering/Spec.hs
+++ b/test/rendering/Spec.hs
@@ -7,8 +7,6 @@
 import qualified Data.ByteString.Lazy as BS
 import Error.Diagnose(diagnosticToJson)
 #endif
-import Data.HashMap.Lazy (HashMap)
-import qualified Data.HashMap.Lazy as HashMap
 import Error.Diagnose
   ( Marker (..),
     Note (..),
@@ -29,11 +27,11 @@ import Prettyprinter.Util (reflow)
 import Prettyprinter.Render.Terminal (AnsiStyle, Color (..), color, bold, italicized, underlined)
 import Data.Traversable (mapAccumL)
 import Data.Functor.Compose (Compose(..))
+import Data.Foldable (Foldable(..))
 
 main :: IO ()
 main = do
-  let files :: HashMap FilePath String =
-        HashMap.fromList
+  let files :: [(FilePath, String)] =
           [ ("test.zc", "let id<a>(x : a) : a := x + 1\nrec fix(f) := f(fix(f))\nlet const<a, b>(x : a, y : b) : a := x"),
             ("somefile.zc", "let id<a>(x : a) : a := x\n  + 1"),
             ("err.nst", "\n\n\n\n    = jmp g\n\n    g: forall(s: Ts, e: Tc).{ %r0: *s64 | s -> e }"),
@@ -89,8 +87,8 @@ main = do
           nestingReport
         ]
 
-  let diag = HashMap.foldlWithKey' addFile (foldl addReport mempty reports) files
-      customDiag = HashMap.foldlWithKey' addFile (foldl addReport mempty customAnnReports) files
+  let diag = foldl' (fmap uncurry addFile) (foldl addReport mempty reports) files
+      customDiag = foldl' (fmap uncurry addFile) (foldl addReport mempty customAnnReports) files
 
   hPutStrLn stdout "\n\nWith unicode: ─────────────────────────\n"
   printDiagnostic stdout WithUnicode (TabSize 4) defaultStyle diag


### PR DESCRIPTION
This lightens the dependency footprint of
`diagnose` by dropping the dependency on
`unordered-containers`.