### PR TITLE
Allow user-specific conversion of Megaparsec custom error component

### DIFF
--- a/src/Error/Diagnose.hs
+++ b/src/Error/Diagnose.hs
@@ -220,6 +220,8 @@ import Error.Diagnose.Style as Export
 --   One simply needs to convert the 'Text.Megaparsec.ParseErrorBundle' which is returned by running a parser into a 'Diagnostic' by using 'Error.Diagnose.Compat.Megaparsec.diagnosticFromBundle'.
 --   Several wrappers are included for easy creation of kinds (error, warning) of diagnostics.
 --
+--  A specific instance of 'HasHint' may be provided to convert the user-specific Parser error (the @e@ in megaparsec's @Parse e s@) into a Diagnose 'Report'.
+--
 --   __Note:__ the returned diagnostic does not include file contents, which needs to be added manually afterwards.
 --
 --   As a quick example:

--- a/src/Error/Diagnose/Compat/Hints.hs
+++ b/src/Error/Diagnose/Compat/Hints.hs
@@ -8,6 +8,9 @@ import Error.Diagnose (Note, Position, Report)
 class HasHints e msg where
   -- | Defines all the hints associated with a given custom error.
   hints :: e -> [Note msg]
+  -- | Allows a custom conversion of a user-specific megaparsec error (the @e@ in
+  -- megaparsec's @Parser e s@) into a Diagnose 'Report'.  A default Report is
+  -- provided in the event that there is no useful customization.
   mkReports :: [Report msg] -> Position -> e -> [Report msg]
 
   hints = const mempty

--- a/src/Error/Diagnose/Compat/Hints.hs
+++ b/src/Error/Diagnose/Compat/Hints.hs
@@ -2,15 +2,21 @@
 
 module Error.Diagnose.Compat.Hints where
 
-import Error.Diagnose (Note)
+import Error.Diagnose (Note, Position, Report)
     
 -- | A class mapping custom errors of type @e@ with messages of type @msg@.
 class HasHints e msg where
   -- | Defines all the hints associated with a given custom error.
   hints :: e -> [Note msg]
+  mkReports :: [Report msg] -> Position -> e -> [Report msg]
+
+  hints = const mempty
+  mkReports defRep _pos _e = defRep
+
 
 -- this is a sane default for 'Void'
 -- but this can be redefined
 --
 -- instance HasHints Void msg where
 --   hints _ = mempty
+--   mkReport defRep _ _ = defRep

--- a/src/Error/Diagnose/Compat/Megaparsec.hs
+++ b/src/Error/Diagnose/Compat/Megaparsec.hs
@@ -33,6 +33,11 @@ import Error.Diagnose.Compat.Hints (HasHints (..))
 import qualified Text.Megaparsec as MP
 
 -- | Transforms a megaparsec 'MP.ParseErrorBundle' into a well-formated 'Diagnostic' ready to be shown.
+--
+-- This may be accompanied by providing a specific instance of 'HasHints' for the
+-- specific user error type used with megaparsec (i.e. the @e@ in @Parser e s@).
+-- If no specific instance is provided, a default error report with no hints is
+-- generated.
 diagnosticFromBundle ::
   forall msg s e.
   (IsString msg, MP.Stream s, HasHints e msg, MP.ShowErrorComponent e, MP.VisualStream s, MP.TraversableStream s) =>


### PR DESCRIPTION
The megaparsec parser allows the user to specify a custom error type (the `e` in Parsec e s`) which the user may use to provide specific errors.

The diagnose `megaparsec-compat` support simply asks megaparsec for a pretty version of any error generated; if the error is a single line, it's reported with `This`, if it's two lines, it's `This` then `Where`, and if it's more than two lines, diagnose drops the megaparsec error output and simply reports `<<Unknown error>>`.  

In my target situation, I wanted to use Diagnose as the custom error type as well (`Parsec (Diagnose Text) Text`), but since Diagnose errors are more than 2 lines, the result was simply `<<Unknown error>>`.

This patch adds a `mkReports` to the `Hint` class (the class could have been renamed to adjust to this new functionality, but I wanted to keep the change set minimal).  When there is a megaparsec `FancyError` (i.e. the user's custom error), it calls this `mkReports` to allow the user to determine how the report should be generated.  The standard report described above is provided as a default.

I also provided default implementations for both `Hint` methods so that the user does not have supply an instance. 